### PR TITLE
Rails 3.1.0+ compatibility (and a few other minor improvements)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
 require 'rubygems'
-require 'spec/rake/spectask'
+require 'rspec/core/rake_task'
 
 [:mysql, :mysql2, :postgresql].each do |adapter|
   desc "Run specs for #{adapter} adapter"
-  Spec::Rake::SpecTask.new("spec:#{adapter.to_s}") do |t|
-    t.spec_files = FileList["spec/#{adapter}/*_spec.rb"]
+  RSpec::Core::RakeTask.new("spec:#{adapter.to_s}") do |spec|
+    spec.pattern = "spec/#{adapter}/*_spec.rb"
+    spec.rspec_opts = ['--backtrace']
   end
 end
 

--- a/lib/spatial_adapter/mysql.rb
+++ b/lib/spatial_adapter/mysql.rb
@@ -87,11 +87,9 @@ module ActiveRecord
       #MySql-specific geometry string parsing. By default, MySql returns geometries in strict wkb format with "0" characters in the first 4 positions.
       def self.string_to_geometry(string)
         return string unless string.is_a?(String)
-        begin
-          GeoRuby::SimpleFeatures::Geometry.from_ewkb(string[4..-1])
-        rescue Exception => exception
-          nil
-        end
+        GeoRuby::SimpleFeatures::Geometry.from_ewkb(string[4..-1])
+      rescue Exception => exception
+        nil
       end
     end
   end

--- a/lib/spatial_adapter/mysql.rb
+++ b/lib/spatial_adapter/mysql.rb
@@ -88,7 +88,7 @@ module ActiveRecord
       def self.string_to_geometry(string)
         return string unless string.is_a?(String)
         GeoRuby::SimpleFeatures::Geometry.from_ewkb(string[4..-1])
-      rescue Exception => exception
+      rescue Exception
         nil
       end
     end

--- a/lib/spatial_adapter/mysql2.rb
+++ b/lib/spatial_adapter/mysql2.rb
@@ -87,7 +87,7 @@ module ActiveRecord
       def self.string_to_geometry(string)
         return string unless string.is_a?(String)
         GeoRuby::SimpleFeatures::Geometry.from_ewkb(string[4..-1])
-      rescue Exception => exception
+      rescue Exception
         nil
       end
     end

--- a/lib/spatial_adapter/mysql2.rb
+++ b/lib/spatial_adapter/mysql2.rb
@@ -86,11 +86,9 @@ module ActiveRecord
       #MySql-specific geometry string parsing. By default, MySql returns geometries in strict wkb format with "0" characters in the first 4 positions.
       def self.string_to_geometry(string)
         return string unless string.is_a?(String)
-        begin
-          GeoRuby::SimpleFeatures::Geometry.from_ewkb(string[4..-1])
-        rescue Exception => exception
-          nil
-        end
+        GeoRuby::SimpleFeatures::Geometry.from_ewkb(string[4..-1])
+      rescue Exception => exception
+        nil
       end
     end
   end

--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -29,10 +29,6 @@ module SpatialAdapter
       postgis_major_version > 1 || (postgis_major_version == 1 && postgis_minor_version >= 5)
     end
 
-    def native_database_types
-      super.merge(geometry_data_types)
-    end
-
     def type_cast(value, column)
       if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
         value.as_hex_ewkb
@@ -122,6 +118,10 @@ module SpatialAdapter
     end
 
     included do
+      def native_database_types
+        super.merge(geometry_data_types)
+      end
+
       def columns(table_name, name = nil) #:nodoc:
         raw_geom_infos = column_spatial_info(table_name)
 

--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -117,11 +117,11 @@ module SpatialAdapter
       raw_geom_infos
     end
 
-    included do
-      def native_database_types
-        super.merge(geometry_data_types)
-      end
+    def native_database_types
+      super.merge(geometry_data_types)
+    end
 
+    included do
       def columns(table_name, name = nil) #:nodoc:
         raw_geom_infos = column_spatial_info(table_name)
 

--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -1,236 +1,240 @@
 require 'spatial_adapter'
 require 'active_record/connection_adapters/postgresql_adapter'
 
+module SpatialAdapter
+  module PostgreSQLAdapterExtensions
+    extend ActiveSupport::Concern
+
+    def postgis_version
+      select_value("SELECT postgis_full_version()").scan(/POSTGIS="([\d\.]*)"/)[0][0]
+    rescue ActiveRecord::StatementInvalid
+      nil
+    end
+
+    def postgis_major_version
+      version = postgis_version
+      version ? version.scan(/^(\d)\.\d\.\d$/)[0][0].to_i : nil
+    end
+
+    def postgis_minor_version
+      version = postgis_version
+      version ? version.scan(/^\d\.(\d)\.\d$/)[0][0].to_i : nil
+    end
+
+    def spatial?
+      !postgis_version.nil?
+    end
+
+    def supports_geographic?
+      postgis_major_version > 1 || (postgis_major_version == 1 && postgis_minor_version >= 5)
+    end
+
+    def native_database_types
+      super.merge(geometry_data_types)
+    end
+
+    #Redefines the quote method to add behaviour for when a Geometry is encountered
+    def quote(value, column = nil)
+      if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
+        "'#{value.as_hex_ewkb}'"
+      else
+        super
+      end
+    end
+
+    def create_table(table_name, options = {})
+      # Using the subclassed table definition
+      table_definition = ActiveRecord::ConnectionAdapters::PostgreSQLTableDefinition.new(self)
+      table_definition.primary_key(options[:primary_key] || ActiveRecord::Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
+
+      yield table_definition if block_given?
+
+      if options[:force] && table_exists?(table_name)
+        drop_table(table_name, options)
+      end
+
+      create_sql = "CREATE#{' TEMPORARY' if options[:temporary]} TABLE "
+      create_sql << "#{quote_table_name(table_name)} ("
+      create_sql << table_definition.to_sql
+      create_sql << ") #{options[:options]}"
+
+      # This is the additional portion for PostGIS
+      unless table_definition.geom_columns.nil?
+        table_definition.geom_columns.each do |geom_column|
+          geom_column.table_name = table_name
+          create_sql << "; " + geom_column.to_sql
+        end
+      end
+
+      execute create_sql
+    end
+
+    def remove_column(table_name, *column_names)
+      column_names = column_names.flatten
+      columns(table_name).each do |col|
+        if column_names.include?(col.name.to_sym)
+          # Geometry columns have to be removed using DropGeometryColumn
+          if col.is_a?(SpatialColumn) && col.spatial? && !col.geographic?
+            execute "SELECT DropGeometryColumn('#{table_name}','#{col.name}')"
+          else
+            super(table_name, col.name)
+          end
+        end
+      end
+    end
+
+    def tables_without_postgis
+      tables - %w{ geometry_columns spatial_ref_sys }
+    end
+
+    def column_spatial_info(table_name)
+      constr = query("SELECT * FROM geometry_columns WHERE f_table_name = '#{table_name}'")
+
+      raw_geom_infos = {}
+      constr.each do |constr_def_a|
+        raw_geom_infos[constr_def_a[3]] ||= SpatialAdapter::RawGeomInfo.new
+        raw_geom_infos[constr_def_a[3]].type = constr_def_a[6]
+        raw_geom_infos[constr_def_a[3]].dimension = constr_def_a[4].to_i
+        raw_geom_infos[constr_def_a[3]].srid = constr_def_a[5].to_i
+
+        if raw_geom_infos[constr_def_a[3]].type[-1] == ?M
+          raw_geom_infos[constr_def_a[3]].with_m = true
+          raw_geom_infos[constr_def_a[3]].type.chop!
+        else
+          raw_geom_infos[constr_def_a[3]].with_m = false
+        end
+      end
+
+      raw_geom_infos.each_value do |raw_geom_info|
+        #check the presence of z and m
+        raw_geom_info.convert!
+      end
+
+      raw_geom_infos
+    end
+
+    included do
+      def columns(table_name, name = nil) #:nodoc:
+        raw_geom_infos = column_spatial_info(table_name)
+
+        column_definitions(table_name).collect do |name, type, default, notnull|
+          case type
+          when /geography/i
+            ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_from_geography(name, default, type, notnull == 'f')
+          when /geometry/i
+            raw_geom_info = raw_geom_infos[name]
+            if raw_geom_info.nil?
+              # This column isn't in the geometry_columns table, so we don't know anything else about it
+              ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_simplified(name, default, notnull == "f")
+            else
+              ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.new(name, default, raw_geom_info.type, notnull == "f", raw_geom_info.srid, raw_geom_info.with_z, raw_geom_info.with_m)
+            end
+          else
+            ActiveRecord::ConnectionAdapters::PostgreSQLColumn.new(name, default, type, notnull == "f")
+          end
+        end
+      end
+
+      alias :original_add_column :add_column
+      def add_column(table_name, column_name, type, options = {})
+        unless geometry_data_types[type].nil?
+          geom_column = ActiveRecord::ConnectionAdapters::PostgreSQLColumnDefinition.new(self, column_name, type, nil, nil, options[:null], options[:srid] || -1 , options[:with_z] || false , options[:with_m] || false, options[:geographic] || false)
+          if geom_column.geographic
+            default = options[:default]
+            notnull = options[:null] == false
+
+            execute("ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{geom_column.to_sql}")
+
+            change_column_default(table_name, column_name, default) if options_include_default?(options)
+            change_column_null(table_name, column_name, false, default) if notnull
+          else
+            geom_column.table_name = table_name
+            execute geom_column.to_sql
+          end
+        else
+          original_add_column(table_name, column_name, type, options)
+        end
+      end
+
+      # Adds an index to a column.
+      def add_index(table_name, column_name, options = {})
+        column_names = Array(column_name)
+        index_name   = index_name(table_name, :column => column_names)
+
+        if Hash === options # legacy support, since this param was a string
+          index_type = options[:unique] ? "UNIQUE" : ""
+          index_name = options[:name] || index_name
+          index_method = options[:spatial] ? 'USING GIST' : ""
+        else
+          index_type = options
+        end
+        quoted_column_names = column_names.map { |e| quote_column_name(e) }.join(", ")
+        execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_method} (#{quoted_column_names})"
+      end
+
+      # Returns the list of all indexes for a table.
+      #
+      # This is a full replacement for the ActiveRecord method and as a result
+      # has a higher probability of breaking in future releases.
+      def indexes(table_name, name = nil)
+         schemas = schema_search_path.split(/,/).map { |p| quote(p) }.join(',')
+
+         # Changed from upstread: link to pg_am to grab the index type (e.g. "gist")
+         result = query(<<-SQL, name)
+           SELECT distinct i.relname, d.indisunique, d.indkey, t.oid, am.amname
+             FROM pg_class t, pg_class i, pg_index d, pg_attribute a, pg_am am
+           WHERE i.relkind = 'i'
+             AND d.indexrelid = i.oid
+             AND d.indisprimary = 'f'
+             AND t.oid = d.indrelid
+             AND t.relname = '#{table_name}'
+             AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN (#{schemas}) )
+             AND i.relam = am.oid
+             AND a.attrelid = t.oid
+          ORDER BY i.relname
+        SQL
+
+        indexes = result.map do |row|
+          index_name = row[0]
+          unique = row[1] == 't'
+          indkey = row[2].split(" ")
+          oid = row[3]
+          indtype = row[4]
+
+          # Changed from upstream: need to get the column types to test for spatial indexes
+          columns = query(<<-SQL, "Columns for index #{row[0]} on #{table_name}").inject({}) {|attlist, r| attlist[r[1]] = [r[0], r[2]]; attlist}
+          SELECT a.attname, a.attnum, t.typname
+          FROM pg_attribute a, pg_type t
+          WHERE a.attrelid = #{oid}
+          AND a.attnum IN (#{indkey.join(",")})
+          AND a.atttypid = t.oid
+          SQL
+
+          # Only GiST indexes on spatial columns denote a spatial index
+          spatial = indtype == 'gist' && columns.size == 1 && (columns.values.first[1] == 'geometry' || columns.values.first[1] == 'geography')
+
+          column_names = indkey.map {|attnum| columns[attnum] ? columns[attnum][0] : nil }
+          ActiveRecord::ConnectionAdapters::IndexDefinition.new(table_name, index_name, unique, column_names, spatial)
+        end
+      end
+
+      def disable_referential_integrity(&block) #:nodoc:
+        if supports_disable_referential_integrity?
+          execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+        end
+        yield
+      ensure
+        if supports_disable_referential_integrity?
+          execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+        end
+      end
+    end
+  end
+end
+
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
   include SpatialAdapter
-  
-  def postgis_version
-    select_value("SELECT postgis_full_version()").scan(/POSTGIS="([\d\.]*)"/)[0][0]
-  rescue ActiveRecord::StatementInvalid
-    nil
-  end
-  
-  def postgis_major_version
-    version = postgis_version
-    version ? version.scan(/^(\d)\.\d\.\d$/)[0][0].to_i : nil
-  end
-  
-  def postgis_minor_version
-    version = postgis_version
-    version ? version.scan(/^\d\.(\d)\.\d$/)[0][0].to_i : nil
-  end
-  
-  def spatial?
-    !postgis_version.nil?
-  end
-  
-  def supports_geographic?
-    postgis_major_version > 1 || (postgis_major_version == 1 && postgis_minor_version >= 5)
-  end
-  
-  alias :original_native_database_types :native_database_types
-  def native_database_types
-    original_native_database_types.merge!(geometry_data_types)
-  end
-
-  alias :original_quote :quote
-  #Redefines the quote method to add behaviour for when a Geometry is encountered
-  def quote(value, column = nil)
-    if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
-      "'#{value.as_hex_ewkb}'"
-    else
-      original_quote(value,column)
-    end
-  end
-
-  def columns(table_name, name = nil) #:nodoc:
-    raw_geom_infos = column_spatial_info(table_name)
-    
-    column_definitions(table_name).collect do |name, type, default, notnull|
-      case type
-      when /geography/i
-        ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_from_geography(name, default, type, notnull == 'f')
-      when /geometry/i
-        raw_geom_info = raw_geom_infos[name]
-        if raw_geom_info.nil?
-          # This column isn't in the geometry_columns table, so we don't know anything else about it
-          ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_simplified(name, default, notnull == "f")
-        else
-          ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.new(name, default, raw_geom_info.type, notnull == "f", raw_geom_info.srid, raw_geom_info.with_z, raw_geom_info.with_m)
-        end
-      else
-        ActiveRecord::ConnectionAdapters::PostgreSQLColumn.new(name, default, type, notnull == "f")
-      end
-    end
-  end
-
-  def create_table(table_name, options = {})
-    # Using the subclassed table definition
-    table_definition = ActiveRecord::ConnectionAdapters::PostgreSQLTableDefinition.new(self)
-    table_definition.primary_key(options[:primary_key] || ActiveRecord::Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
-
-    yield table_definition if block_given?
-
-    if options[:force] && table_exists?(table_name)
-      drop_table(table_name, options)
-    end
-
-    create_sql = "CREATE#{' TEMPORARY' if options[:temporary]} TABLE "
-    create_sql << "#{quote_table_name(table_name)} ("
-    create_sql << table_definition.to_sql
-    create_sql << ") #{options[:options]}"
-
-    # This is the additional portion for PostGIS
-    unless table_definition.geom_columns.nil?
-      table_definition.geom_columns.each do |geom_column|
-        geom_column.table_name = table_name
-        create_sql << "; " + geom_column.to_sql
-      end
-    end
-
-    execute create_sql
-  end
-
-  alias :original_remove_column :remove_column
-  def remove_column(table_name, *column_names)
-    column_names = column_names.flatten
-    columns(table_name).each do |col|
-      if column_names.include?(col.name.to_sym)
-        # Geometry columns have to be removed using DropGeometryColumn
-        if col.is_a?(SpatialColumn) && col.spatial? && !col.geographic?
-          execute "SELECT DropGeometryColumn('#{table_name}','#{col.name}')"
-        else
-          original_remove_column(table_name, col.name)
-        end
-      end
-    end
-  end
-  
-  alias :original_add_column :add_column
-  def add_column(table_name, column_name, type, options = {})
-    unless geometry_data_types[type].nil?
-      geom_column = ActiveRecord::ConnectionAdapters::PostgreSQLColumnDefinition.new(self, column_name, type, nil, nil, options[:null], options[:srid] || -1 , options[:with_z] || false , options[:with_m] || false, options[:geographic] || false)
-      if geom_column.geographic
-        default = options[:default]
-        notnull = options[:null] == false
-        
-        execute("ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{geom_column.to_sql}")
-
-        change_column_default(table_name, column_name, default) if options_include_default?(options)
-        change_column_null(table_name, column_name, false, default) if notnull
-      else
-        geom_column.table_name = table_name
-        execute geom_column.to_sql
-      end
-    else
-      original_add_column(table_name, column_name, type, options)
-    end
-  end
-
-  # Adds an index to a column.
-  def add_index(table_name, column_name, options = {})
-    column_names = Array(column_name)
-    index_name   = index_name(table_name, :column => column_names)
-
-    if Hash === options # legacy support, since this param was a string
-      index_type = options[:unique] ? "UNIQUE" : ""
-      index_name = options[:name] || index_name
-      index_method = options[:spatial] ? 'USING GIST' : ""
-    else
-      index_type = options
-    end
-    quoted_column_names = column_names.map { |e| quote_column_name(e) }.join(", ")
-    execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_method} (#{quoted_column_names})"
-  end
-
-  # Returns the list of all indexes for a table.
-  #
-  # This is a full replacement for the ActiveRecord method and as a result
-  # has a higher probability of breaking in future releases.
-  def indexes(table_name, name = nil)
-     schemas = schema_search_path.split(/,/).map { |p| quote(p) }.join(',')
-     
-     # Changed from upstread: link to pg_am to grab the index type (e.g. "gist")
-     result = query(<<-SQL, name)
-       SELECT distinct i.relname, d.indisunique, d.indkey, t.oid, am.amname
-         FROM pg_class t, pg_class i, pg_index d, pg_attribute a, pg_am am
-       WHERE i.relkind = 'i'
-         AND d.indexrelid = i.oid
-         AND d.indisprimary = 'f'
-         AND t.oid = d.indrelid
-         AND t.relname = '#{table_name}'
-         AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN (#{schemas}) )
-         AND i.relam = am.oid
-         AND a.attrelid = t.oid
-      ORDER BY i.relname
-    SQL
-
-    indexes = result.map do |row|
-      index_name = row[0]
-      unique = row[1] == 't'
-      indkey = row[2].split(" ")
-      oid = row[3]
-      indtype = row[4]
-
-      # Changed from upstream: need to get the column types to test for spatial indexes
-      columns = query(<<-SQL, "Columns for index #{row[0]} on #{table_name}").inject({}) {|attlist, r| attlist[r[1]] = [r[0], r[2]]; attlist}
-      SELECT a.attname, a.attnum, t.typname
-      FROM pg_attribute a, pg_type t
-      WHERE a.attrelid = #{oid}
-      AND a.attnum IN (#{indkey.join(",")})
-      AND a.atttypid = t.oid
-      SQL
-
-      # Only GiST indexes on spatial columns denote a spatial index
-      spatial = indtype == 'gist' && columns.size == 1 && (columns.values.first[1] == 'geometry' || columns.values.first[1] == 'geography')
-
-      column_names = indkey.map {|attnum| columns[attnum] ? columns[attnum][0] : nil }
-      ActiveRecord::ConnectionAdapters::IndexDefinition.new(table_name, index_name, unique, column_names, spatial)
-    end
-  end
-
-  def disable_referential_integrity(&block) #:nodoc:
-    if supports_disable_referential_integrity?
-      execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
-    end
-    yield
-  ensure
-    if supports_disable_referential_integrity?
-      execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
-    end
-  end
-
-  private
-  
-  def tables_without_postgis
-    tables - %w{ geometry_columns spatial_ref_sys }
-  end
-  
-  def column_spatial_info(table_name)
-    constr = query("SELECT * FROM geometry_columns WHERE f_table_name = '#{table_name}'")
-
-    raw_geom_infos = {}
-    constr.each do |constr_def_a|
-      raw_geom_infos[constr_def_a[3]] ||= SpatialAdapter::RawGeomInfo.new
-      raw_geom_infos[constr_def_a[3]].type = constr_def_a[6]
-      raw_geom_infos[constr_def_a[3]].dimension = constr_def_a[4].to_i
-      raw_geom_infos[constr_def_a[3]].srid = constr_def_a[5].to_i
-
-      if raw_geom_infos[constr_def_a[3]].type[-1] == ?M
-        raw_geom_infos[constr_def_a[3]].with_m = true
-        raw_geom_infos[constr_def_a[3]].type.chop!
-      else
-        raw_geom_infos[constr_def_a[3]].with_m = false
-      end
-    end
-
-    raw_geom_infos.each_value do |raw_geom_info|
-      #check the presence of z and m
-      raw_geom_info.convert!
-    end
-
-    raw_geom_infos
-  end
+  include SpatialAdapter::PostgreSQLAdapterExtensions
 end
 
 module ActiveRecord

--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -33,6 +33,14 @@ module SpatialAdapter
       super.merge(geometry_data_types)
     end
 
+    def type_cast(value, column)
+      if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
+        value.as_hex_ewkb
+      else
+        super
+      end
+    end
+
     #Redefines the quote method to add behaviour for when a Geometry is encountered
     def quote(value, column = nil)
       if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)

--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -1,248 +1,245 @@
 require 'spatial_adapter'
 require 'active_record/connection_adapters/postgresql_adapter'
 
-module SpatialAdapter
-  module PostgreSQLAdapterExtensions
-    extend ActiveSupport::Concern
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
+  include SpatialAdapter
+  
+  def postgis_version
+    select_value("SELECT postgis_full_version()").scan(/POSTGIS="([\d\.]*)"/)[0][0]
+  rescue ActiveRecord::StatementInvalid
+    nil
+  end
+  
+  def postgis_major_version
+    version = postgis_version
+    version ? version.scan(/^(\d)\.\d\.\d$/)[0][0].to_i : nil
+  end
+  
+  def postgis_minor_version
+    version = postgis_version
+    version ? version.scan(/^\d\.(\d)\.\d$/)[0][0].to_i : nil
+  end
+  
+  def spatial?
+    !postgis_version.nil?
+  end
+  
+  def supports_geographic?
+    postgis_major_version > 1 || (postgis_major_version == 1 && postgis_minor_version >= 5)
+  end
+  
+  alias :original_native_database_types :native_database_types
+  def native_database_types
+    original_native_database_types.merge!(geometry_data_types)
+  end
 
-    def postgis_version
-      select_value("SELECT postgis_full_version()").scan(/POSTGIS="([\d\.]*)"/)[0][0]
-    rescue ActiveRecord::StatementInvalid
-      nil
+  alias :original_type_cast :type_cast
+  def type_cast(value, column)
+    if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
+      value.as_hex_ewkb
+    else
+      original_type_cast(value, column)
     end
+  end
 
-    def postgis_major_version
-      version = postgis_version
-      version ? version.scan(/^(\d)\.\d\.\d$/)[0][0].to_i : nil
+  alias :original_quote :quote
+  #Redefines the quote method to add behaviour for when a Geometry is encountered
+  def quote(value, column = nil)
+    if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
+      "'#{value.as_hex_ewkb}'"
+    else
+      original_quote(value,column)
     end
+  end
 
-    def postgis_minor_version
-      version = postgis_version
-      version ? version.scan(/^\d\.(\d)\.\d$/)[0][0].to_i : nil
-    end
-
-    def spatial?
-      !postgis_version.nil?
-    end
-
-    def supports_geographic?
-      postgis_major_version > 1 || (postgis_major_version == 1 && postgis_minor_version >= 5)
-    end
-
-    def type_cast(value, column)
-      if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
-        value.as_hex_ewkb
+  def columns(table_name, name = nil) #:nodoc:
+    raw_geom_infos = column_spatial_info(table_name)
+    
+    column_definitions(table_name).collect do |name, type, default, notnull|
+      case type
+      when /geography/i
+        ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_from_geography(name, default, type, notnull == 'f')
+      when /geometry/i
+        raw_geom_info = raw_geom_infos[name]
+        if raw_geom_info.nil?
+          # This column isn't in the geometry_columns table, so we don't know anything else about it
+          ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_simplified(name, default, notnull == "f")
+        else
+          ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.new(name, default, raw_geom_info.type, notnull == "f", raw_geom_info.srid, raw_geom_info.with_z, raw_geom_info.with_m)
+        end
       else
-        super
+        ActiveRecord::ConnectionAdapters::PostgreSQLColumn.new(name, default, type, notnull == "f")
+      end
+    end
+  end
+
+  def create_table(table_name, options = {})
+    # Using the subclassed table definition
+    table_definition = ActiveRecord::ConnectionAdapters::PostgreSQLTableDefinition.new(self)
+    table_definition.primary_key(options[:primary_key] || ActiveRecord::Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
+
+    yield table_definition if block_given?
+
+    if options[:force] && table_exists?(table_name)
+      drop_table(table_name, options)
+    end
+
+    create_sql = "CREATE#{' TEMPORARY' if options[:temporary]} TABLE "
+    create_sql << "#{quote_table_name(table_name)} ("
+    create_sql << table_definition.to_sql
+    create_sql << ") #{options[:options]}"
+
+    # This is the additional portion for PostGIS
+    unless table_definition.geom_columns.nil?
+      table_definition.geom_columns.each do |geom_column|
+        geom_column.table_name = table_name
+        create_sql << "; " + geom_column.to_sql
       end
     end
 
-    #Redefines the quote method to add behaviour for when a Geometry is encountered
-    def quote(value, column = nil)
-      if value.kind_of?(GeoRuby::SimpleFeatures::Geometry)
-        "'#{value.as_hex_ewkb}'"
-      else
-        super
-      end
-    end
+    execute create_sql
+  end
 
-    def create_table(table_name, options = {})
-      # Using the subclassed table definition
-      table_definition = ActiveRecord::ConnectionAdapters::PostgreSQLTableDefinition.new(self)
-      table_definition.primary_key(options[:primary_key] || ActiveRecord::Base.get_primary_key(table_name.to_s.singularize)) unless options[:id] == false
-
-      yield table_definition if block_given?
-
-      if options[:force] && table_exists?(table_name)
-        drop_table(table_name, options)
-      end
-
-      create_sql = "CREATE#{' TEMPORARY' if options[:temporary]} TABLE "
-      create_sql << "#{quote_table_name(table_name)} ("
-      create_sql << table_definition.to_sql
-      create_sql << ") #{options[:options]}"
-
-      # This is the additional portion for PostGIS
-      unless table_definition.geom_columns.nil?
-        table_definition.geom_columns.each do |geom_column|
-          geom_column.table_name = table_name
-          create_sql << "; " + geom_column.to_sql
-        end
-      end
-
-      execute create_sql
-    end
-
-    def remove_column(table_name, *column_names)
-      column_names = column_names.flatten
-      columns(table_name).each do |col|
-        if column_names.include?(col.name.to_sym)
-          # Geometry columns have to be removed using DropGeometryColumn
-          if col.is_a?(SpatialColumn) && col.spatial? && !col.geographic?
-            execute "SELECT DropGeometryColumn('#{table_name}','#{col.name}')"
-          else
-            super(table_name, col.name)
-          end
-        end
-      end
-    end
-
-    def tables_without_postgis
-      tables - %w{ geometry_columns spatial_ref_sys }
-    end
-
-    def column_spatial_info(table_name)
-      constr = query("SELECT * FROM geometry_columns WHERE f_table_name = '#{table_name}'")
-
-      raw_geom_infos = {}
-      constr.each do |constr_def_a|
-        raw_geom_infos[constr_def_a[3]] ||= SpatialAdapter::RawGeomInfo.new
-        raw_geom_infos[constr_def_a[3]].type = constr_def_a[6]
-        raw_geom_infos[constr_def_a[3]].dimension = constr_def_a[4].to_i
-        raw_geom_infos[constr_def_a[3]].srid = constr_def_a[5].to_i
-
-        if raw_geom_infos[constr_def_a[3]].type[-1] == ?M
-          raw_geom_infos[constr_def_a[3]].with_m = true
-          raw_geom_infos[constr_def_a[3]].type.chop!
+  alias :original_remove_column :remove_column
+  def remove_column(table_name, *column_names)
+    column_names = column_names.flatten
+    columns(table_name).each do |col|
+      if column_names.include?(col.name.to_sym)
+        # Geometry columns have to be removed using DropGeometryColumn
+        if col.is_a?(SpatialColumn) && col.spatial? && !col.geographic?
+          execute "SELECT DropGeometryColumn('#{table_name}','#{col.name}')"
         else
-          raw_geom_infos[constr_def_a[3]].with_m = false
-        end
-      end
-
-      raw_geom_infos.each_value do |raw_geom_info|
-        #check the presence of z and m
-        raw_geom_info.convert!
-      end
-
-      raw_geom_infos
-    end
-
-    def native_database_types
-      super.merge(geometry_data_types)
-    end
-
-    included do
-      def columns(table_name, name = nil) #:nodoc:
-        raw_geom_infos = column_spatial_info(table_name)
-
-        column_definitions(table_name).collect do |name, type, default, notnull|
-          case type
-          when /geography/i
-            ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_from_geography(name, default, type, notnull == 'f')
-          when /geometry/i
-            raw_geom_info = raw_geom_infos[name]
-            if raw_geom_info.nil?
-              # This column isn't in the geometry_columns table, so we don't know anything else about it
-              ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.create_simplified(name, default, notnull == "f")
-            else
-              ActiveRecord::ConnectionAdapters::SpatialPostgreSQLColumn.new(name, default, raw_geom_info.type, notnull == "f", raw_geom_info.srid, raw_geom_info.with_z, raw_geom_info.with_m)
-            end
-          else
-            ActiveRecord::ConnectionAdapters::PostgreSQLColumn.new(name, default, type, notnull == "f")
-          end
-        end
-      end
-
-      alias :original_add_column :add_column
-      def add_column(table_name, column_name, type, options = {})
-        unless geometry_data_types[type].nil?
-          geom_column = ActiveRecord::ConnectionAdapters::PostgreSQLColumnDefinition.new(self, column_name, type, nil, nil, options[:null], options[:srid] || -1 , options[:with_z] || false , options[:with_m] || false, options[:geographic] || false)
-          if geom_column.geographic
-            default = options[:default]
-            notnull = options[:null] == false
-
-            execute("ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{geom_column.to_sql}")
-
-            change_column_default(table_name, column_name, default) if options_include_default?(options)
-            change_column_null(table_name, column_name, false, default) if notnull
-          else
-            geom_column.table_name = table_name
-            execute geom_column.to_sql
-          end
-        else
-          original_add_column(table_name, column_name, type, options)
-        end
-      end
-
-      # Adds an index to a column.
-      def add_index(table_name, column_name, options = {})
-        column_names = Array(column_name)
-        index_name   = index_name(table_name, :column => column_names)
-
-        if Hash === options # legacy support, since this param was a string
-          index_type = options[:unique] ? "UNIQUE" : ""
-          index_name = options[:name] || index_name
-          index_method = options[:spatial] ? 'USING GIST' : ""
-        else
-          index_type = options
-        end
-        quoted_column_names = column_names.map { |e| quote_column_name(e) }.join(", ")
-        execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_method} (#{quoted_column_names})"
-      end
-
-      # Returns the list of all indexes for a table.
-      #
-      # This is a full replacement for the ActiveRecord method and as a result
-      # has a higher probability of breaking in future releases.
-      def indexes(table_name, name = nil)
-         schemas = schema_search_path.split(/,/).map { |p| quote(p) }.join(',')
-
-         # Changed from upstread: link to pg_am to grab the index type (e.g. "gist")
-         result = query(<<-SQL, name)
-           SELECT distinct i.relname, d.indisunique, d.indkey, t.oid, am.amname
-             FROM pg_class t, pg_class i, pg_index d, pg_attribute a, pg_am am
-           WHERE i.relkind = 'i'
-             AND d.indexrelid = i.oid
-             AND d.indisprimary = 'f'
-             AND t.oid = d.indrelid
-             AND t.relname = '#{table_name}'
-             AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN (#{schemas}) )
-             AND i.relam = am.oid
-             AND a.attrelid = t.oid
-          ORDER BY i.relname
-        SQL
-
-        indexes = result.map do |row|
-          index_name = row[0]
-          unique = row[1] == 't'
-          indkey = row[2].split(" ")
-          oid = row[3]
-          indtype = row[4]
-
-          # Changed from upstream: need to get the column types to test for spatial indexes
-          columns = query(<<-SQL, "Columns for index #{row[0]} on #{table_name}").inject({}) {|attlist, r| attlist[r[1]] = [r[0], r[2]]; attlist}
-          SELECT a.attname, a.attnum, t.typname
-          FROM pg_attribute a, pg_type t
-          WHERE a.attrelid = #{oid}
-          AND a.attnum IN (#{indkey.join(",")})
-          AND a.atttypid = t.oid
-          SQL
-
-          # Only GiST indexes on spatial columns denote a spatial index
-          spatial = indtype == 'gist' && columns.size == 1 && (columns.values.first[1] == 'geometry' || columns.values.first[1] == 'geography')
-
-          column_names = indkey.map {|attnum| columns[attnum] ? columns[attnum][0] : nil }
-          ActiveRecord::ConnectionAdapters::IndexDefinition.new(table_name, index_name, unique, column_names, spatial)
-        end
-      end
-
-      def disable_referential_integrity(&block) #:nodoc:
-        if supports_disable_referential_integrity?
-          execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
-        end
-        yield
-      ensure
-        if supports_disable_referential_integrity?
-          execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+          original_remove_column(table_name, col.name)
         end
       end
     end
   end
-end
+  
+  alias :original_add_column :add_column
+  def add_column(table_name, column_name, type, options = {})
+    unless geometry_data_types[type].nil?
+      geom_column = ActiveRecord::ConnectionAdapters::PostgreSQLColumnDefinition.new(self, column_name, type, nil, nil, options[:null], options[:srid] || -1 , options[:with_z] || false , options[:with_m] || false, options[:geographic] || false)
+      if geom_column.geographic
+        default = options[:default]
+        notnull = options[:null] == false
+        
+        execute("ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{geom_column.to_sql}")
 
-ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
-  include SpatialAdapter
-  include SpatialAdapter::PostgreSQLAdapterExtensions
+        change_column_default(table_name, column_name, default) if options_include_default?(options)
+        change_column_null(table_name, column_name, false, default) if notnull
+      else
+        geom_column.table_name = table_name
+        execute geom_column.to_sql
+      end
+    else
+      original_add_column(table_name, column_name, type, options)
+    end
+  end
+
+  # Adds an index to a column.
+  def add_index(table_name, column_name, options = {})
+    column_names = Array(column_name)
+    index_name   = index_name(table_name, :column => column_names)
+
+    if Hash === options # legacy support, since this param was a string
+      index_type = options[:unique] ? "UNIQUE" : ""
+      index_name = options[:name] || index_name
+      index_method = options[:spatial] ? 'USING GIST' : ""
+    else
+      index_type = options
+    end
+    quoted_column_names = column_names.map { |e| quote_column_name(e) }.join(", ")
+    execute "CREATE #{index_type} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_method} (#{quoted_column_names})"
+  end
+
+  # Returns the list of all indexes for a table.
+  #
+  # This is a full replacement for the ActiveRecord method and as a result
+  # has a higher probability of breaking in future releases.
+  def indexes(table_name, name = nil)
+     schemas = schema_search_path.split(/,/).map { |p| quote(p) }.join(',')
+     
+     # Changed from upstread: link to pg_am to grab the index type (e.g. "gist")
+     result = query(<<-SQL, name)
+       SELECT distinct i.relname, d.indisunique, d.indkey, t.oid, am.amname
+         FROM pg_class t, pg_class i, pg_index d, pg_attribute a, pg_am am
+       WHERE i.relkind = 'i'
+         AND d.indexrelid = i.oid
+         AND d.indisprimary = 'f'
+         AND t.oid = d.indrelid
+         AND t.relname = '#{table_name}'
+         AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN (#{schemas}) )
+         AND i.relam = am.oid
+         AND a.attrelid = t.oid
+      ORDER BY i.relname
+    SQL
+
+    indexes = result.map do |row|
+      index_name = row[0]
+      unique = row[1] == 't'
+      indkey = row[2].split(" ")
+      oid = row[3]
+      indtype = row[4]
+
+      # Changed from upstream: need to get the column types to test for spatial indexes
+      columns = query(<<-SQL, "Columns for index #{row[0]} on #{table_name}").inject({}) {|attlist, r| attlist[r[1]] = [r[0], r[2]]; attlist}
+      SELECT a.attname, a.attnum, t.typname
+      FROM pg_attribute a, pg_type t
+      WHERE a.attrelid = #{oid}
+      AND a.attnum IN (#{indkey.join(",")})
+      AND a.atttypid = t.oid
+      SQL
+
+      # Only GiST indexes on spatial columns denote a spatial index
+      spatial = indtype == 'gist' && columns.size == 1 && (columns.values.first[1] == 'geometry' || columns.values.first[1] == 'geography')
+
+      column_names = indkey.map {|attnum| columns[attnum] ? columns[attnum][0] : nil }
+      ActiveRecord::ConnectionAdapters::IndexDefinition.new(table_name, index_name, unique, column_names, spatial)
+    end
+  end
+
+  def disable_referential_integrity(&block) #:nodoc:
+    if supports_disable_referential_integrity?
+      execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+    end
+    yield
+  ensure
+    if supports_disable_referential_integrity?
+      execute(tables_without_postgis.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+    end
+  end
+
+  private
+  
+  def tables_without_postgis
+    tables - %w{ geometry_columns spatial_ref_sys }
+  end
+  
+  def column_spatial_info(table_name)
+    constr = query("SELECT * FROM geometry_columns WHERE f_table_name = '#{table_name}'")
+
+    raw_geom_infos = {}
+    constr.each do |constr_def_a|
+      raw_geom_infos[constr_def_a[3]] ||= SpatialAdapter::RawGeomInfo.new
+      raw_geom_infos[constr_def_a[3]].type = constr_def_a[6]
+      raw_geom_infos[constr_def_a[3]].dimension = constr_def_a[4].to_i
+      raw_geom_infos[constr_def_a[3]].srid = constr_def_a[5].to_i
+
+      if raw_geom_infos[constr_def_a[3]].type[-1] == ?M
+        raw_geom_infos[constr_def_a[3]].with_m = true
+        raw_geom_infos[constr_def_a[3]].type.chop!
+      else
+        raw_geom_infos[constr_def_a[3]].with_m = false
+      end
+    end
+
+    raw_geom_infos.each_value do |raw_geom_info|
+      #check the presence of z and m
+      raw_geom_info.convert!
+    end
+
+    raw_geom_infos
+  end
 end
 
 module ActiveRecord

--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -5,11 +5,9 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
   include SpatialAdapter
   
   def postgis_version
-    begin
-      select_value("SELECT postgis_full_version()").scan(/POSTGIS="([\d\.]*)"/)[0][0]
-    rescue ActiveRecord::StatementInvalid
-      nil
-    end
+    select_value("SELECT postgis_full_version()").scan(/POSTGIS="([\d\.]*)"/)[0][0]
+  rescue ActiveRecord::StatementInvalid
+    nil
   end
   
   def postgis_major_version

--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -193,7 +193,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
       # Only GiST indexes on spatial columns denote a spatial index
       spatial = indtype == 'gist' && columns.size == 1 && (columns.values.first[1] == 'geometry' || columns.values.first[1] == 'geography')
 
-      column_names = indkey.map {|attnum| columns[attnum] ? columns[attnum][0] : nil }
+      column_names = indkey.map {|attnum| columns[attnum] ? columns[attnum][0] : nil }.compact
       ActiveRecord::ConnectionAdapters::IndexDefinition.new(table_name, index_name, unique, column_names, spatial)
     end
   end

--- a/lib/spatial_adapter/railtie.rb
+++ b/lib/spatial_adapter/railtie.rb
@@ -1,13 +1,14 @@
 module SpatialAdapter
   class Railtie < Rails::Railtie
     initializer "spatial_adapter.load_current_database_adapter" do
-      adapter = ActiveRecord::Base.configurations[Rails.env]['adapter']
-      begin
-        require "spatial_adapter/#{adapter}"
-      rescue LoadError
-        raise SpatialAdapter::NotCompatibleError.new("spatial_adapter does not currently support the #{adapter} database.")
+      ActiveSupport.on_load :active_record do
+        adapter = ActiveRecord::Base.configurations[Rails.env]['adapter']
+        begin
+          require "spatial_adapter/#{adapter}"
+        rescue LoadError
+          raise SpatialAdapter::NotCompatibleError.new("spatial_adapter does not currently support the #{adapter} database.")
+        end
       end
     end
   end
 end
-

--- a/spec/postgresql/connection_adapter_spec.rb
+++ b/spec/postgresql/connection_adapter_spec.rb
@@ -13,6 +13,10 @@ describe "Modified PostgreSQLAdapter" do
     it 'should include the geometry types' do
       @connection.native_database_types.should include(@connection.geometry_data_types)
     end
+
+    it 'should include the basic types' do
+      @connection.native_database_types.should include(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES)
+    end
   end
 
   describe '#postgis_version' do

--- a/spec/postgresql/connection_adapter_spec.rb
+++ b/spec/postgresql/connection_adapter_spec.rb
@@ -8,7 +8,13 @@ describe "Modified PostgreSQLAdapter" do
     postgis_connection
     @connection = ActiveRecord::Base.connection
   end
-  
+
+  describe '#native_database_types' do
+    it 'should include the geometry types' do
+      @connection.native_database_types.should include(@connection.geometry_data_types)
+    end
+  end
+
   describe '#postgis_version' do
     it 'should report a version number if PostGIS is installed' do
       @connection.should_receive(:select_value).with('SELECT postgis_full_version()').and_return('POSTGIS="1.5.0" GEOS="3.2.0-CAPI-1.6.0" PROJ="Rel. 4.7.1, 23 September 2009" LIBXML="2.7.6" USE_STATS')

--- a/spec/postgresql/connection_adapter_spec.rb
+++ b/spec/postgresql/connection_adapter_spec.rb
@@ -219,19 +219,18 @@ describe "Modified PostgreSQLAdapter" do
   end  
   
   describe "#add_index" do
-    after :each do
-      @connection.should_receive(:execute).with(any_args())
+    it "should create a spatial index given :spatial => true" do
+      @connection.add_index('geometry_models', 'geom', :spatial => true)
+      @connection.indexes('geometry_models').first.spatial.should be_true
+      @connection.indexes('geometry_models').first.columns.should == ['geom']
       @connection.remove_index('geometry_models', 'geom')
     end
     
-    it "should create a spatial index given :spatial => true" do
-      @connection.should_receive(:execute).with(/using gist/i)
-      @connection.add_index('geometry_models', 'geom', :spatial => true)
-    end
-    
     it "should not create a spatial index unless specified" do
-      @connection.should_not_receive(:execute).with(/using gist/i)
       @connection.add_index('geometry_models', 'extra')
+      @connection.indexes('geometry_models').first.spatial.should be_false
+      @connection.indexes('geometry_models').first.columns.should == ['extra']
+      @connection.remove_index('geometry_models', 'extra')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'spec'
+require 'rspec'
 require 'geo_ruby'
 gem 'activerecord', '=3.0.3'
 require 'active_record'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'rspec'
 require 'geo_ruby'
-gem 'activerecord', '=3.0.3'
+gem 'activerecord', '>=3.0.3'
 require 'active_record'
 
 $:.unshift((File.join(File.dirname(__FILE__), '..', 'lib')))


### PR DESCRIPTION
Hey there,

I made some improvements to spatial adapter to get it working under Rails 3.1.0 for my own use, and posted about fork here: #26

Several people have confirmed that it works for them and one has suggested a pull request, so here it is.

One issue, which I noted in my original comment to that thread:

> I have a working fix, but still an outstanding issue or two. Most notably, the schema dumper doesn't seem to be picking up its extensions, when run from within my rails project. The schema dumper specs pass.
> 
> Also note I've only been testing on postgres.
