### PR TITLE
Caching results from geometry_columns

### DIFF
--- a/lib/spatial_adapter/postgresql.rb
+++ b/lib/spatial_adapter/postgresql.rb
@@ -213,7 +213,9 @@ module ActiveRecord::ConnectionAdapters
     end
 
     def column_spatial_info(table_name)
-      if !@raw_geom_infos_cache[table_name]
+      cache = @raw_geom_infos_cache ||= Hash.new
+
+      if !cache[table_name]
         constr = query("SELECT * FROM geometry_columns WHERE f_table_name = '#{table_name}'")
 
         raw_geom_infos = {}
@@ -235,9 +237,10 @@ module ActiveRecord::ConnectionAdapters
           #check the presence of z and m
           raw_geom_info.convert!
         end
-        @raw_geom_infos_cache[table_name] = raw_geom_infos
+        cache[table_name] = raw_geom_infos
       end
-      @raw_geom_infos_cache[table_name]
+      @raw_geom_infos_cache = cache
+      cache[table_name]
     end
   end
 


### PR DESCRIPTION
Noticed there were a very large number of queries hitting the geometry_columns table in general.  This change will cache the geometry information once per table per instance of PostgreSQLAdapter and return the memory object on subsequent requests.
